### PR TITLE
修复make install的报错问题

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ foreach(filepath ${TS_FILES})
 endforeach()
 qt5_create_translation(QM_FILES ${CMAKE_CURRENT_SOURCE_DIR} ${ts_files_replaced})
 
-add_custom_target(translations ADD DEPENDS ${QM_FILES} SOURCES ${ts_files_replaced})
+add_custom_target(translations ALL DEPENDS ${QM_FILES} SOURCES ${ts_files_replaced})
 
 install(TARGETS lingmo-filemanager RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES lingmo-filemanager.desktop DESTINATION "/usr/share/applications")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,7 @@ foreach(filepath ${TS_FILES})
 endforeach()
 qt5_create_translation(QM_FILES ${CMAKE_CURRENT_SOURCE_DIR} ${ts_files_replaced})
 
-add_custom_target(translations DEPENDS ${QM_FILES} SOURCES ${ts_files_replaced})
-add_dependencies(lingmo-filemanager translations)
+add_custom_target(translations ADD DEPENDS ${QM_FILES} SOURCES ${ts_files_replaced})
 
 install(TARGETS lingmo-filemanager RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES lingmo-filemanager.desktop DESTINATION "/usr/share/applications")


### PR DESCRIPTION
```
-- Configuring done (3.1s)
-- Generating done (0.1s)
-- Build files have been written to: /home/intro/Lingmo-Build/lingmo-filemanager/build
[  1%] Automatic MOC and UIC for target lingmo-filemanager
[  1%] Built target lingmo-filemanager_autogen
[ 32%] Built target lingmo-filemanager
[100%] Built target translations
Install the project...
-- Install configuration: ""
-- Installing: /usr/bin/lingmo-filemanager
-- Installing: /usr/share/applications/lingmo-filemanager.desktop
-- Installing: /usr/share/lingmo-filemanager/translations/ar_AA.qm
-- Installing: /usr/share/lingmo-filemanager/translations/be_BY.qm
-- Installing: /usr/share/lingmo-filemanager/translations/be_Latn.qm
-- Installing: /usr/share/lingmo-filemanager/translations/bg_BG.qm
-- Installing: /usr/share/lingmo-filemanager/translations/bs_BA.qm
-- Installing: /usr/share/lingmo-filemanager/translations/cs_CZ.qm
-- Installing: /usr/share/lingmo-filemanager/translations/da_DK.qm
-- Installing: /usr/share/lingmo-filemanager/translations/de_DE.qm
-- Installing: /usr/share/lingmo-filemanager/translations/en_US.qm
-- Installing: /usr/share/lingmo-filemanager/translations/eo_XX.qm
-- Installing: /usr/share/lingmo-filemanager/translations/es_ES.qm
-- Installing: /usr/share/lingmo-filemanager/translations/es_MX.qm
-- Installing: /usr/share/lingmo-filemanager/translations/fa_IR.qm
-- Installing: /usr/share/lingmo-filemanager/translations/fi_FI.qm
-- Installing: /usr/share/lingmo-filemanager/translations/fr_FR.qm
-- Installing: /usr/share/lingmo-filemanager/translations/he_IL.qm
-- Installing: /usr/share/lingmo-filemanager/translations/hi_IN.qm
-- Installing: /usr/share/lingmo-filemanager/translations/hu_HU.qm
-- Installing: /usr/share/lingmo-filemanager/translations/id_ID.qm
-- Installing: /usr/share/lingmo-filemanager/translations/ie.qm
-- Installing: /usr/share/lingmo-filemanager/translations/it_IT.qm
-- Installing: /usr/share/lingmo-filemanager/translations/ja_JP.qm
-- Installing: /usr/share/lingmo-filemanager/translations/lt_LT.qm
-- Installing: /usr/share/lingmo-filemanager/translations/lv_LV.qm
-- Installing: /usr/share/lingmo-filemanager/translations/ml_IN.qm
-- Installing: /usr/share/lingmo-filemanager/translations/nb_NO.qm
-- Installing: /usr/share/lingmo-filemanager/translations/ne_NP.qm
-- Installing: /usr/share/lingmo-filemanager/translations/pl_PL.qm
-- Installing: /usr/share/lingmo-filemanager/translations/pt_BR.qm
-- Installing: /usr/share/lingmo-filemanager/translations/pt_PT.qm
-- Installing: /usr/share/lingmo-filemanager/translations/ro_RO.qm
-- Installing: /usr/share/lingmo-filemanager/translations/ru_RU.qm
-- Installing: /usr/share/lingmo-filemanager/translations/si_LK.qm
-- Installing: /usr/share/lingmo-filemanager/translations/sk_SK.qm
-- Installing: /usr/share/lingmo-filemanager/translations/so.qm
-- Installing: /usr/share/lingmo-filemanager/translations/sr_RS.qm
-- Installing: /usr/share/lingmo-filemanager/translations/sv_SE.qm
-- Installing: /usr/share/lingmo-filemanager/translations/sw.qm
-- Installing: /usr/share/lingmo-filemanager/translations/ta_IN.qm
-- Installing: /usr/share/lingmo-filemanager/translations/tr_TR.qm
-- Installing: /usr/share/lingmo-filemanager/translations/uk_UA.qm
-- Installing: /usr/share/lingmo-filemanager/translations/uz_UZ.qm
-- Installing: /usr/share/lingmo-filemanager/translations/zh_CN.qm
-- Installing: /usr/share/lingmo-filemanager/translations/zh_TW.qm
```

安装已通过